### PR TITLE
cache data.js ajax request

### DIFF
--- a/js/fedmenu.js
+++ b/js/fedmenu.js
@@ -110,6 +110,7 @@ var fedmenu = function(options) { $(document).ready(function() {
         url: o.url,
         mimeType: o.mimeType,
         dataType: 'script',
+        cache: true,
         error: function(err) {
             console.log('Error getting ' + o.url);
             console.log(err);


### PR DESCRIPTION
Because the `$.ajax` call for data.js retrieval uses
`dataType: 'script'`, caching is disabled by default.
(jQuery adds a dummy timestamp query parameter)
It however seems that data.js is rather static, so it makes sense
to cache it, which would make the whole Fedmenu cacheable so that
it's loaded much faster.
See http://api.jquery.com/jquery.ajax/
